### PR TITLE
modified one instruction which prevented looping over multiple warts files

### DIFF
--- a/sc_warts.py
+++ b/sc_warts.py
@@ -523,7 +523,9 @@ class WartsReader(object):
       return wd
     else:
       print "Unsupported object: %02x Len: %d" % (typ, length)
-      sys.exit(-1)
+      return False #with this commmand, I could run my program over several warts files, 
+      #instead of having to run my script for each file separately due to the sys.exit() instruction
+      #sys.exit(-1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
"return False" instead of "sys.exit(-1)" in the function "next_object()" in "sc_warts().py"